### PR TITLE
Markdown Parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"dotenv": "^16.0.3",
 				"jsonwebtoken": "^9.0.0",
 				"jwt-encode": "^1.0.1",
+				"marked": "^9.0.3",
 				"mongodb": "^5.2.0",
 				"razorpay": "^2.8.6",
 				"svelte-markdown": "^0.2.3",
@@ -1976,14 +1977,14 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.0.3.tgz",
+			"integrity": "sha512-pI/k4nzBG1PEq1J3XFEHxVvjicfjl8rgaMaqclouGSMPhk7Q3Ejb2ZRxx/ZQOcQ1909HzVoWCFYq6oLgtL4BpQ==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
 			"engines": {
-				"node": ">= 12"
+				"node": ">= 16"
 			}
 		},
 		"node_modules/memory-pager": {
@@ -3199,6 +3200,17 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.0.0"
+			}
+		},
+		"node_modules/svelte-markdown/node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/svelte-preprocess": {
@@ -5022,9 +5034,9 @@
 			}
 		},
 		"marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.0.3.tgz",
+			"integrity": "sha512-pI/k4nzBG1PEq1J3XFEHxVvjicfjl8rgaMaqclouGSMPhk7Q3Ejb2ZRxx/ZQOcQ1909HzVoWCFYq6oLgtL4BpQ=="
 		},
 		"memory-pager": {
 			"version": "1.5.0",
@@ -5826,6 +5838,13 @@
 			"requires": {
 				"@types/marked": "^4.0.1",
 				"marked": "^4.0.10"
+			},
+			"dependencies": {
+				"marked": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+					"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+				}
 			}
 		},
 		"svelte-preprocess": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"svelte-check": "^3.0.1",
 				"tailwindcss": "^3.3.1",
 				"typescript": "^5.0.0",
-				"vite": "^4.2.0"
+				"vite": "4.2.3"
 			}
 		},
 		"node_modules/@auth/core": {
@@ -3542,9 +3542,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
-			"integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.3.tgz",
+			"integrity": "sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==",
 			"dependencies": {
 				"esbuild": "^0.17.5",
 				"postcss": "^8.4.21",
@@ -6065,9 +6065,9 @@
 			}
 		},
 		"vite": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
-			"integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.3.tgz",
+			"integrity": "sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==",
 			"requires": {
 				"esbuild": "^0.17.5",
 				"fsevents": "~2.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"svelte-check": "^3.0.1",
 		"tailwindcss": "^3.3.1",
 		"typescript": "^5.0.0",
-		"vite": "^4.2.0"
+		"vite": "4.2.3"
 	},
 	"type": "module",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"dotenv": "^16.0.3",
 		"jsonwebtoken": "^9.0.0",
 		"jwt-encode": "^1.0.1",
+		"marked": "^9.0.3",
 		"mongodb": "^5.2.0",
 		"razorpay": "^2.8.6",
 		"svelte-markdown": "^0.2.3",

--- a/src/lib/events_pg/MDConverter.svelte
+++ b/src/lib/events_pg/MDConverter.svelte
@@ -1,0 +1,24 @@
+<script>
+    import marked from "marked";
+
+    /**
+     * Markdown source to be parsed into raw HTML.
+     * @type string
+     */
+    export let markdown;
+
+    /**
+     * Convert a markdown source into a raw HTML string.
+     * @example ```{@html toHTML(markdown)}```
+     *
+     * @param {string} markdown
+     * @return string
+     */
+    function toHTML(markdown) {
+        return marked.marked(markdown);
+    }
+</script>
+
+<div class="md-converter">
+    {@html toHTML(markdown)}
+</div>


### PR DESCRIPTION
Made the following changes:

1. Added a new component: `MDConverter.svelte`.
2. Installed a dependency `marked`.
3. Updated Vite to version `4.2.3`.

`MDConverter` converts a raw Markdown string into valid HTML which is rendered in a `<div>` with class `md-converter` using Svelte's `{@html foo}`.

Vite version `4.2.3` fixes some vulnerabilities in the previous version we were using.